### PR TITLE
add seed setting to helper functions in example creator functions

### DIFF
--- a/R/podlove_create_example_dl_ep.R
+++ b/R/podlove_create_example_dl_ep.R
@@ -57,9 +57,12 @@ podlove_create_example_dl_ep <-  function(n_dls,
     dl_un <- tibble::tibble(
       y = runif(n_un, 0, max_ln))
       
-    create_peak <- function(n_values, max_y) {
+    create_peak <- function(n_values, max_y, seed = NULL) {
       # helper function to create one random normal distributed peak
       # (viral tune-ins)
+      
+      if (!is.null(seed)) set.seed(seed)
+      
       pk <- tibble::tibble(
         y = rnorm(n = n_values,
                   mean = sample(1:max_y, 1),

--- a/R/podlove_create_example_downloads.R
+++ b/R/podlove_create_example_downloads.R
@@ -86,7 +86,10 @@ podlove_create_example_downloads <- function(df_posts,
   n_total_dls <- nrow(downloads)
   
   # helper function to create random hex strings (for request_id)
-  randhex <- function(n_chars) {
+  randhex <- function(n_chars, seed = NULL) {
+    
+    if (!is.null(seed)) set.seed(seed)
+    
     paste(sample(c(0:9, letters[1:6]), n_chars, TRUE), collapse = "")
   }
   
@@ -108,7 +111,7 @@ podlove_create_example_downloads <- function(df_posts,
                                          prob = wakefield::probs(nrow(df_useragents)))) %>% 
     # generate random request_ids
     dplyr::rowwise() %>% 
-      dplyr::mutate(request_id = randhex(32)) %>% 
+      dplyr::mutate(request_id = randhex(32, seed = seed)) %>% 
     dplyr::ungroup() %>%
     
     # join the release dates from the mediafile df and calculate download times


### PR DESCRIPTION
The seed parameter wasn't properly handed over to helper functions within podlove_create_example_*() functions.