### PR TITLE
1.0.7: Bugfix for cleaning script

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: podlover
 Type: Package
 Title: Collects, Cleans and Analyzes Podcast Download Data from Podlove Publisher
-Version: 1.0.6
+Version: 1.0.7
 Authors@R: person("Timm", "Suess", email = "catchall@sporez.com", 
     role = c("aut", "cre"))
 URL: https://github.com/lordyo/podlover

--- a/R/podlove_get_and_clean.R
+++ b/R/podlove_get_and_clean.R
@@ -10,6 +10,8 @@
 #' @param db_host hostname of the database
 #' @param db_user username of the database 
 #' @param db_password password of the database
+#' @param ddupe boolean switcher for legacy deduplication. Don't use this until
+#'     you know what you're doing.
 #' @param launch_date date of the first official podcast episode release
 #' @param tbl_prefix prefix of the MySLQ table names, defaults to `wp_`
 #' @param tbl_downloads name of the MySQL table for clean downloads (without the prefix)
@@ -44,6 +46,7 @@ podlove_get_and_clean <- function(db_name = rstudioapi::askForSecret(name = "dbn
                                   db_user = rstudioapi::askForSecret(name = "user", message = "Enter the user name of the database", title = "User Name"),
                                   db_password = rstudioapi::askForSecret(name = "password", message = "Enter the Password", title = "Password"),
 																	launch_date = NULL,
+																	ddupe = FALSE,
 																	tbl_prefix = "wp_",
 																	tbl_downloads = "podlove_downloadintentclean",
 																	tbl_mediafile = "podlove_mediafile",
@@ -107,7 +110,8 @@ podlove_get_and_clean <- function(db_name = rstudioapi::askForSecret(name = "dbn
 	                                  tables[[df_names[3]]],
 	                                  tables[[df_names[4]]],
 	                                  tables[[df_names[5]]],
-																		launch_date)
+																		launch_date,
+																		ddupe = ddupe)
 	
 	message("tables connected and data cleaned")
 	

--- a/man/podlove_clean_stats.Rd
+++ b/man/podlove_clean_stats.Rd
@@ -10,6 +10,7 @@ podlove_clean_stats(
   df_user,
   df_episodes,
   df_posts,
+  ddupe = FALSE,
   launch_date = NULL
 )
 }
@@ -23,6 +24,9 @@ podlove_clean_stats(
 \item{df_episodes}{contents of the MySQL table \code{wp_podlove_episode}}
 
 \item{df_posts}{contents of the MySQL table \code{wp_posts}}
+
+\item{ddupe}{boolean switcher for legacy deduplication. Don't use this until
+you know what you're doing.}
 
 \item{launch_date}{date of the first official podcast episode release,
 defaults to date of first download attempt (which may be before the first

--- a/man/podlove_get_and_clean.Rd
+++ b/man/podlove_get_and_clean.Rd
@@ -14,6 +14,7 @@ podlove_get_and_clean(
   db_password = rstudioapi::askForSecret(name = "password", message =
     "Enter the Password", title = "Password"),
   launch_date = NULL,
+  ddupe = FALSE,
   tbl_prefix = "wp_",
   tbl_downloads = "podlove_downloadintentclean",
   tbl_mediafile = "podlove_mediafile",
@@ -32,6 +33,9 @@ podlove_get_and_clean(
 \item{db_password}{password of the database}
 
 \item{launch_date}{date of the first official podcast episode release}
+
+\item{ddupe}{boolean switcher for legacy deduplication. Don't use this until
+you know what you're doing.}
 
 \item{tbl_prefix}{prefix of the MySLQ table names, defaults to `wp_`}
 

--- a/tests/testthat/test_cleaning.R
+++ b/tests/testthat/test_cleaning.R
@@ -25,8 +25,8 @@ test_that("clean_stats returns a dataframe", {
 
 test_that("clean_stats returns correct dimensions", {
 	expect_equal(ncol(t_clean), 20)
-	expect_equal(nrow(t_clean), 4310)
-	expect_equal(nrow(t_clean_ld), 1167) # launchdate filter works
+	expect_equal(nrow(t_clean), 5140)
+	expect_equal(nrow(t_clean_ld), 1188) # launchdate filter works
 })
 
 test_that("clean_stats has the correct column names", {


### PR DESCRIPTION
The cleaning script scrubbed too much of the existing data, even though it had been cleaned by Podlove itself. Each combination of episode/source/context/client/os was counted only as one download within an hour range. This has been fixed, but is still accessible via the ddupe option in clean_stats() and get_and_clean(). 